### PR TITLE
Fixed C Stack Overflow issues and made serveral DX improvements

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,33 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build",
+      "type": "shell",
+
+      "windows": {
+        "command": ".\\compile.bat"
+      },
+      "osx": {
+        "command": "bash",
+        "args": ["./compile.sh"]
+      },
+      "linux": {
+        "command": "bash",
+        "args": ["./compile.sh"]
+      },
+
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Session:Close()
 Session:SaveToFile(LogFile)
 ```
 
-# Compilation with DarkLua
+# Compilation
+
+## Windows
 
 - Run compile.bat and check compiled folder
+
+## Linux/MacOS
+
+1. Install [rokit](https://github.com/rojo-rbx/rokit) if you haven't already
+2. Open the command-line shell of your liking and [cd to this repository](https://www.quora.com/What-does-it-mean-to-CD-into-a-directory-and-how-can-I-do-that-Can-someone-explain-it-in-a-laymans-term)
+3. Run `rokit install` and wait for it to install all the dependencies
+4. Run `sh compile.sh` and check compiled folder

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,2 @@
+darklua process -c config.json -v main.luau compiled/Calligraph.luau
+echo 	- Release compiled!

--- a/compiled/Calligraph.luau
+++ b/compiled/Calligraph.luau
@@ -773,6 +773,7 @@ local LuaEncodeAndEvaluateInstancePath = __DARKLUA_BUNDLE_MODULES.load('a')
 local LuaEncodeCore, EvaluateInstancePath = LuaEncodeAndEvaluateInstancePath.LuaEncode, LuaEncodeAndEvaluateInstancePath.EvaluateInstancePath
 local HookMgr = __DARKLUA_BUNDLE_MODULES.load('b')
 local Utils = __DARKLUA_BUNDLE_MODULES.load('c')
+local DebugInfo = getrenv and getrenv().debug.info or debug.info
 local JSONEncode = function(...): string
     if shared.DirectCall.__namecall then
         return shared.DirectCall.__namecall(HttpService, 'JSONEncode', ...)
@@ -801,7 +802,7 @@ local JSONLogConstructors: LogConstructorSet = {
         return JSONEncode({
             Time = os.clock(),
             Type = 'FunctionCall',
-            Name = FunctionPath or debug.info(Function, 'n') or tostring(Function),
+            Name = FunctionPath or DebugInfo(Function, 'n') or tostring(Function),
             Args = LuaEncode(Args),
             Return = LuaEncode(Return),
         })
@@ -874,7 +875,7 @@ end
 
 local CodeLogConstructors: LogConstructorSet = {
     FunctionCall = function(Function, Args, Return, FunctionPath)
-        local FunctionName = FunctionPath or debug.info(Function, 'n') or `<Anonymous {tostring(Function)}>`
+        local FunctionName = FunctionPath or DebugInfo(Function, 'n') or `<Anonymous {tostring(Function)}>`
 
         return string.format('%s(%s) --> %s', FunctionName, FormatCodeArgs(Args), LuaEncode(Return))
     end,
@@ -1023,7 +1024,7 @@ function Calligraph.NewFunctionProxy(
             return Old(...)
         end
 
-        local CallSource = debug.info(4, 's')
+        local CallSource = DebugInfo(4, 's')
 
         if not table.find(Session.Targets, CallSource) then
             return Old(...)
@@ -1207,7 +1208,7 @@ function Calligraph:NewSession(Targets: {string}, Configuration: SessionConfigur
                 return Old(Self, Index)
             end
 
-            local CallSource = debug.info(4, 's')
+            local CallSource = DebugInfo(4, 's')
 
             if not table.find(Session.Targets, CallSource) then
                 return Old(Self, Index)
@@ -1240,7 +1241,7 @@ function Calligraph:NewSession(Targets: {string}, Configuration: SessionConfigur
                 return Old(Self, Index, Value)
             end
 
-            local CallSource = debug.info(4, 's')
+            local CallSource = DebugInfo(4, 's')
 
             if not table.find(Session.Targets, CallSource) then
                 return Old(Self, Index, Value)
@@ -1261,7 +1262,7 @@ function Calligraph:NewSession(Targets: {string}, Configuration: SessionConfigur
                 return Old(Self, ...)
             end
 
-            local CallSource = debug.info(4, 's')
+            local CallSource = DebugInfo(4, 's')
 
             if not table.find(Session.Targets, CallSource) then
                 return Old(Self, ...)
@@ -1332,7 +1333,7 @@ function Calligraph:NewSession(Targets: {string}, Configuration: SessionConfigur
         ScanAndHookWhitelisted(getrenv())
     end
     if Session.Configuration.LogMetamethodFunctionFetches then
-        HookMgr.RegisterHook(`Calligraph:{Session.GUID}:MetamethodFunctionFetch`, getrenv().debug.info, function(
+        shared.DirectCall.DebugInfo = HookMgr.RegisterHook(`Calligraph:{Session.GUID}:MetamethodFunctionFetch`, getrenv().debug.info, function(
             Old,
             ...
         )
@@ -1340,28 +1341,27 @@ function Calligraph:NewSession(Targets: {string}, Configuration: SessionConfigur
                 return Old(...)
             end
 
-            local Success, Return, _ = Utils.GetReturnData(Old, ...)
+            local Success, Return, ReturnN = Utils.GetReturnData(Old, ...)
 
-            if Success then
-                if #Return == 1 then
-                    local Value = Return[1]
+            if not Success then
+                return Old(...)
+            end
 
-                    if typeof(Value) == 'function' and iscclosure(Value) then
-                        if GameMetamethods[Return] then
-                            task.spawn(function()
-                                Session.Log(string.format('[!!!] Raw metamethod function fetched: %s', tostring(Value)))
-                            end)
+            for i = 1, ReturnN do
+                local Value = Return[i]
 
-                            if Session.Configuration.MetaMethodFunctionFetchTrap then
-                                return coroutine.yield()
-                            end
-                        end
+                if typeof(Value) == 'function' and iscclosure(Value) and GameMetamethods[Return] then
+                    task.spawn(Session.Log, string.format('[!!!] Raw metamethod function fetched: %s', tostring(Value)))
+
+                    if Session.Configuration.MetaMethodFunctionFetchTrap then
+                        return coroutine.yield()
                     end
                 end
             end
 
             return Old(...)
         end)
+        DebugInfo = shared.DirectCall.DebugInfo.Original
     end
 
     return Session

--- a/compiled/Calligraph.luau
+++ b/compiled/Calligraph.luau
@@ -106,7 +106,7 @@ do
             function SerializeString(inputString)
                 return table_concat({
                     '"',
-                    string_gsub(inputString, '[%z\\"\1-\31\127-\u{ff}]', SpecialCharacters),
+                    string_gsub(inputString, '[%z\\"\1-\31\127-\255]', SpecialCharacters),
                     '"',
                 })
             end

--- a/main.luau
+++ b/main.luau
@@ -71,6 +71,9 @@ local LuaEncodeCore, EvaluateInstancePath =
 -- this is so bad but wtv i just need it to work
 local HookMgr = require("./modules/HookMgr.luau")
 local Utils = require("./modules/Utils.luau")
+
+local DebugInfo = getrenv and getrenv().debug.info or debug.info
+
 local JSONEncode = function(...): string
 	if shared.DirectCall.__namecall then
 		return shared.DirectCall.__namecall(HttpService, "JSONEncode", ...)
@@ -106,7 +109,7 @@ local JSONLogConstructors: LogConstructorSet = {
 		return JSONEncode({
 			Time = os.clock(),
 			Type = "FunctionCall",
-			Name = FunctionPath or debug.info(Function, "n") or tostring(Function),
+			Name = FunctionPath or DebugInfo(Function, "n") or tostring(Function),
 			Args = LuaEncode(Args),
 			Return = LuaEncode(Return),
 		})
@@ -180,7 +183,7 @@ end
 
 local CodeLogConstructors: LogConstructorSet = {
 	FunctionCall = function(Function, Args, Return, FunctionPath)
-		local FunctionName = FunctionPath or debug.info(Function, 'n') or `<Anonymous {tostring(Function)}>`
+		local FunctionName = FunctionPath or DebugInfo(Function, 'n') or `<Anonymous {tostring(Function)}>`
 		return string.format("%s(%s) --> %s", FunctionName, FormatCodeArgs(Args), LuaEncode(Return))
 	end,
 	Namecall = function(Instance, Method, Args, Return)
@@ -335,7 +338,7 @@ function Calligraph.NewFunctionProxy(
 			return Old(...)
 		end
 
-		local CallSource = debug.info(4, "s")
+		local CallSource = DebugInfo(4, "s")
 		-- print('log', Old, ...)
 
 		if not table.find(Session.Targets, CallSource) then
@@ -501,7 +504,7 @@ function Calligraph:NewSession(Targets: { string }, Configuration: SessionConfig
 					return Old(Self, Index)
 				end
 
-				local CallSource = debug.info(4, "s")
+				local CallSource = DebugInfo(4, "s")
 
 				if not table.find(Session.Targets, CallSource) then
 					return Old(Self, Index)
@@ -535,7 +538,7 @@ function Calligraph:NewSession(Targets: { string }, Configuration: SessionConfig
 					return Old(Self, Index, Value)
 				end
 
-				local CallSource = debug.info(4, "s")
+				local CallSource = DebugInfo(4, "s")
 
 				if not table.find(Session.Targets, CallSource) then
 					return Old(Self, Index, Value)
@@ -557,7 +560,7 @@ function Calligraph:NewSession(Targets: { string }, Configuration: SessionConfig
 					return Old(Self, ...)
 				end
 
-				local CallSource = debug.info(4, "s")
+				local CallSource = DebugInfo(4, "s")
 
 				if not table.find(Session.Targets, CallSource) then
 					return Old(Self, ...)
@@ -646,31 +649,40 @@ function Calligraph:NewSession(Targets: { string }, Configuration: SessionConfig
 	end
 
 	if Session.Configuration.LogMetamethodFunctionFetches then
-		HookMgr.RegisterHook(`Calligraph:{Session.GUID}:MetamethodFunctionFetch`, getrenv().debug.info, function(Old, ...)
+		shared.DirectCall.DebugInfo = HookMgr.RegisterHook(`Calligraph:{Session.GUID}:MetamethodFunctionFetch`, getrenv().debug.info, function(Old, ...)
 			if checkcaller() then
 				return Old(...)
 			end
-			
-			local Success, Return, _ = Utils.GetReturnData(Old, ...)
 
-			if Success then
-				if #Return == 1 then
-					local Value = Return[1]
-					if typeof(Value) == "function" and iscclosure(Value) then
-						if GameMetamethods[Return] then
-							task.spawn(function()
-								Session.Log(string.format("[!!!] Raw metamethod function fetched: %s", tostring(Value)))
-							end)
-							if Session.Configuration.MetaMethodFunctionFetchTrap then
-								return coroutine.yield()	
-							end
-						end
+			-- This dosent take into account the extra stack levels that are added by calling the function and using pcall in it.
+			-- TODO: Fix not taking into account the extra stack levels added by function calls
+			-- Extra stack depth = 2 (function call to GetReturnData) + 1 (pcall inside GetReturnData) atleast i think
+			local Success, Return, ReturnN = Utils.GetReturnData(Old, ...)
+
+			if not Success then
+				return Old(...)
+			end
+			
+			for i = 1, ReturnN do
+				local Value = Return[i]
+
+				if 
+					typeof(Value) == "function" and
+					iscclosure(Value) and
+					GameMetamethods[Return]
+				then
+					task.spawn(Session.Log, string.format("[!!!] Raw metamethod function fetched: %s", tostring(Value)))
+					if Session.Configuration.MetaMethodFunctionFetchTrap then
+						return coroutine.yield()	
 					end
 				end
 			end
 			
+			-- return table.unpack(Return, 1, ReturnN) -- non valid data due to extra stack levels so when implemented, please remove this comment
 			return Old(...) -- doublecall but whatever i cant be assed to recreate the errors
 		end)
+
+		DebugInfo = shared.DirectCall.DebugInfo.Original
 	end
 
 	return Session

--- a/rokit.toml
+++ b/rokit.toml
@@ -1,0 +1,7 @@
+# This file lists tools managed by Rokit, a toolchain manager for Roblox projects.
+# For more information, see https://github.com/rojo-rbx/rokit
+
+# New tools can be added by running `rokit add <tool>` in a terminal.
+
+[tools]
+darklua = "seaofvoices/darklua@0.17.1"


### PR DESCRIPTION
Root cause of C Stack Overflow issue root cause was due to LogMetamethodFunctionFetches's `debug.info` hook not checking correctly when to return the results which caused the error. Fixed by changing all `debug.info` calls to be using the original unhooked function.

DX improvements include:
```diff
+ VSCode Tasks so you dont need to have a terminal open to build (CTRL + SHIFT + P -> Task: Run Build Task)
+ Added Multi OS Script Bundling support via rokit, should now support macOS and linux
```